### PR TITLE
Add (imcomplete) read API on events & items

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,6 @@
 class EventsController < ApplicationController
   def show
-    @event = Event.find(params[:event_id])
+    @event = Event.find(params[:id])
     render json: @event, include: {event_items: :item}
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,6 @@
+class EventsController < ApplicationController
+  def show
+    @event = Event.find(params[:event_id])
+    render json: @event, include: {event_items: :item}
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,0 +1,6 @@
+class ItemsController < ApplicationController
+  def show
+    @item = Item.find(params[:item_id])
+    render json: @item
+  end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def show
-    @item = Item.find(params[:item_id])
+    @item = Item.find(params[:id])
     render json: @item
   end
 end

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -1,0 +1,25 @@
+class EventSerializer < ActiveModel::Serializer
+  attributes :id, :name
+  
+  # --- JSONのkeyをitemsにできるがitem_idから紐づくitems情報を取得する方法がわからない ---
+  # attribute :evis, key: :items
+  # def evis
+  #   object.event_items
+  # end
+  
+  # --- JSONのevent_itemsの中身のitem情報をpriceと同じ階層に表示できるが、JSONのkey名が公式のページに書いてあるやり方で変えられない ---
+  has_many :event_items
+  class EventItemSerializer < ActiveModel::Serializer
+    attributes :price
+    attribute :item_id
+    attribute :name
+    
+    def item_id
+      object.item.id
+    end
+    
+    def name
+      object.item.name
+    end
+  end
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,0 +1,3 @@
+class ItemSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -1,0 +1,4 @@
+class LogSerializer < ActiveModel::Serializer
+  attributes :id, :diff_count, :created_at, :updated_at
+  has_one :event_item, key: :id
+end

--- a/app/serializers/seller_serializer.rb
+++ b/app/serializers/seller_serializer.rb
@@ -1,0 +1,3 @@
+class SellerSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
+
+  get 'items/:item_id', to: 'items#show'
+  get 'events/:event_id', to: 'events#show'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
-  get 'items/:item_id', to: 'items#show'
-  get 'events/:event_id', to: 'events#show'
+  get 'items/:id', to: 'items#show'
+  get 'events/:id', to: 'events#show'
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- ActiveModel Serializerで出力するJSONのキーを変更するオプションkeyが
    ```ruby
    has_many :event_items, key: :items
    ```
    で指定してもうまくいかない…
- itemsのreadの仕様を忘れたので保留中