### PR TITLE
Fix count error in event serializer

### DIFF
--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -17,8 +17,12 @@ class EventSerializer < ActiveModel::Serializer
     end
 
     def count
-      logs = Log.find_by(event_item_id: object.id)
-      logs.sum(:diff_count) unless logs.nil?
+      logs = Log.where(event_item_id: object.id)
+      if logs.empty?
+        nil
+      else
+        logs.sum(:diff_count)
+      end
     end
   end
 end


### PR DESCRIPTION
/events/:idにアクセスした際にcountでエラーが出るのを修正。