### PR TITLE
GitHubのリポジトリをhttpsプロトコルのURLに変更

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 lock "~> 3.10.0"
 
 set :application, "Regi-Urico-api"
-set :repo_url, "git@github.com:enpitut2017/Regi-Urico-api.git"
+set :repo_url, "https://github.com/enpitut2017/Regi-Urico-api.git"
 
 # Default branch is :master
 # ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp


### PR DESCRIPTION
デプロイ時にGitHubのレポジトリにアクセスできなかった問題を解決しました。