### PR TITLE
複数冊購入時に1冊ごとに1ツイートするように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,3 +503,75 @@ HTTP 401 Unauthorised
     "errors": "Unauthorized"
 }
 ```
+
+## POST [/register]
+
+レジで商品が購入された時、商品在庫数の増減を登録します。
+
+### request
+
+```
+X-Authorized-Token: q2w5ARRr62KEZqGSUGCfzjE6
+```
+
+
+```json
+{
+    "event_id": 1,
+    items: [
+        {
+            "id": 1,
+            "name": "Book1",
+            "count": 3
+        },
+        {
+            "id": 2,
+            "name": "Book2",
+            "count": 5
+        },
+    ]
+}
+```
+
+### response
+
+登録に成功した場合、登録後の最新のアイテムリストが返ります。
+
+```
+HTTP 201 Created
+```
+
+```json
+{
+    "id": 1,
+    "name": "イベント名",
+    "event_items": [
+        {
+            "price": 1400,
+            "item_id": 1,
+            "name": "Book1",
+            "count": 19,
+            "diff_count": 0
+        },
+        {
+            "price": 600,
+            "item_id": 2,
+            "name": "Book2",
+            "count": 28,
+            "diff_count": 0
+        }
+    ]
+}
+```
+
+指定したアイテムが存在しない、または他人のアイテムだった場合
+
+```
+HTTP 400 Bad Request
+```
+
+```json
+{
+    "errors": "there is no such item, event_id: 999, item_id: 777"
+}
+```

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ X-Authorized-Token: q2w5ARRr62KEZqGSUGCfzjE6
 ```json
 {
     "event_id": 1,
-    items: [
+    "items": [
         {
             "id": 1,
             "name": "Book1",

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class RegisterController < ApplicationController
+  before_action :current_seller
+
   def create
     json_request = JSON.parse(request.body.read)
     items = json_request['items']
-    if items.nil?
+    if items.nil? then
       render status: :bad_request
     else
       begin
@@ -12,7 +14,10 @@ class RegisterController < ApplicationController
         ActiveRecord::Base.transaction do
           items.each do |item|
             event_item = EventItem.find_by(event_id: json_request['event_id'], item_id: item['id'])
-            raise ArgumentError if event_item.nil?
+            if event_item.nil? || ! @seller.events.ids.include?(event_item.event_id)
+              raise ArgumentError, "there is no such item, event_id: #{json_request['event_id']}, item_id: #{item['id']}"
+            end
+
             event_item.logs.create(diff_count: item['count'])
             item = Item.find(item['id'])
             tweet = "#{item.seller.name}様の「#{item.name}」は残り#{event_item.logs.sum(:diff_count)}個になりました！"
@@ -24,10 +29,9 @@ class RegisterController < ApplicationController
         tweets.each do |tweet|
           client.update!(tweet)
         end
-        render json: @event, include: { event_items: :item }, status: :created
+        render json: @event, include: {event_items: :item}, status: :created
       rescue => e
-        logger.error e
-        render status: :bad_request
+        render json: {errors: e.message}, status: :bad_request
       end
     end
   end
@@ -40,6 +44,13 @@ class RegisterController < ApplicationController
       config.consumer_secret = ENV['TWITTER_CONSUMER_SECRET']
       config.access_token = ENV['TWITTER_ACCESS_TOKEN']
       config.access_token_secret = ENV['TWITTER_ACCESS_TOKEN_SECRET']
+    end
+  end
+
+  def current_seller()
+    @seller = Seller.find_by(token: request.headers['HTTP_X_AUTHORIZED_TOKEN'])
+    unless @seller
+      render json: {errors: 'Unauthorized'}, status: :unauthorized
     end
   end
 end

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -26,8 +26,21 @@ class RegisterController < ApplicationController
           @event = Event.find(json_request['event_id'])
         end
         client = get_client
+        will_continue = "（続く）"
+        did_continue = "（続き）"
+        tweet_max_size = 140
         tweets.each do |tweet|
-          client.update!(tweet)
+          first_tweet = true
+          while did_continue.size * (first_tweet ? 0 : 1) + tweet.size > tweet_max_size
+            if first_tweet
+              sliced_tweet = tweet.slice!(0, 140 - will_continue.size) + will_continue
+              first_tweet = false
+            else
+              sliced_tweet = did_continue + tweet.slice!(0, 140 - did_continue.size - will_continue.size) + will_continue
+            end
+            client.update!(sliced_tweet)
+          end
+          client.update!(did_continue * (first_tweet ? 0 : 1) + tweet)
         end
         render json: @event, include: {event_items: :item}, status: :created
       rescue => e

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -1,39 +1,45 @@
+# frozen_string_literal: true
+
 class RegisterController < ApplicationController
   def create
     json_request = JSON.parse(request.body.read)
-    items = json_request["items"]
+    items = json_request['items']
     if items.nil?
       render status: :bad_request
     else
       begin
-        tweet = ""
+        tweets = []
         ActiveRecord::Base.transaction do
           items.each do |item|
-            event_item = EventItem.find_by(event_id: json_request["event_id"], item_id: item["id"])
+            event_item = EventItem.find_by(event_id: json_request['event_id'], item_id: item['id'])
             raise ArgumentError if event_item.nil?
-            event_item.logs.create(diff_count: item["count"])
-            item = Item.find(item["id"])
-            tweet << "\n" << "#{item.seller.name}様の「#{item.name}」は残り#{event_item.logs.sum(:diff_count)}個になりました！"
+            event_item.logs.create(diff_count: item['count'])
+            item = Item.find(item['id'])
+            tweet = "#{item.seller.name}様の「#{item.name}」は残り#{event_item.logs.sum(:diff_count)}個になりました！"
+            tweets.push(tweet)
           end
-          @event = Event.find(json_request["event_id"])
+          @event = Event.find(json_request['event_id'])
         end
         client = get_client
-        client.update!(tweet)
-        render json: @event, include: {event_items: :item}, status: :created
+        tweets.each do |tweet|
+          client.update!(tweet)
+        end
+        render json: @event, include: { event_items: :item }, status: :created
       rescue => e
         logger.error e
         render status: :bad_request
       end
     end
   end
-  
-private
+
+  private
+
   def get_client
     Twitter::REST::Client.new do |config|
-      config.consumer_key         = ENV['TWITTER_CONSUMER_KEY']
-      config.consumer_secret      = ENV['TWITTER_CONSUMER_SECRET']
-      config.access_token         = ENV['TWITTER_ACCESS_TOKEN']
-      config.access_token_secret  = ENV['TWITTER_ACCESS_TOKEN_SECRET']
+      config.consumer_key = ENV['TWITTER_CONSUMER_KEY']
+      config.consumer_secret = ENV['TWITTER_CONSUMER_SECRET']
+      config.access_token = ENV['TWITTER_ACCESS_TOKEN']
+      config.access_token_secret = ENV['TWITTER_ACCESS_TOKEN_SECRET']
     end
   end
 end


### PR DESCRIPTION
- 複数冊購入時に1冊ごとに1ツイートするように変更しました。
- POST /register のAPIドキュメントが無かったので追記しました。

ref. #44