### PR TITLE
[WIP] イベントが存在しない場合にデフォルトのイベントを1つ作成するように変更

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,8 +2,12 @@ class EventsController < ApplicationController
   before_action :current_seller
 
   def index
-    @events = @seller.events
-    render json: { events: @events }
+    events = @seller.events
+    if events.empty?
+      default_event= @seller.events.create(name: '新規イベント')
+      events.push(default_event)
+    end
+    render json: { events: events }
   end
 
   def show


### PR DESCRIPTION
[新規ユーザーを作成すると、イベント作成画面が一瞬だけ表示されて、画面が真っ白になってしまう #60](https://github.com/enpitut2017/Regi-Urico-client/issues/60) が上手く解決できなかった時は、これをマージして使いましょう。

<img width="455" alt="2017-12-17 19 02 11" src="https://user-images.githubusercontent.com/1425259/34078392-d7aeb54a-e35c-11e7-833f-88b94e439723.png">
