### PR TITLE
カレントユーザ以外のイベントIDがDELETE [/events]で返らないよう修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -83,7 +83,7 @@ class EventsController < ApplicationController
       @event.destroy
 
       # 最後に更新されたイベントを返す
-      @event = Event.order('updated_at desc').first
+      @event = Event.where(seller: @seller).order('updated_at desc').first
       if @event.nil?
         render status: :no_content
       else


### PR DESCRIPTION
#83 の修正です。
他人のイベントのIDが返ることがあるという深刻なバグでした。