### PR TITLE
API のテストを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 !/tmp/.keep
 .byebug_history
 config/database.yml
+pytest/venv

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,109 @@
 .byebug_history
 config/database.yml
 pytest/venv
+# Created by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# End of https://www.gitignore.io/api/python

--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+simplejson
+requests
+jsonschema

--- a/pytest/support/assertions.py
+++ b/pytest/support/assertions.py
@@ -1,0 +1,20 @@
+from os.path import join, dirname
+import json
+from jsonschema.validators import validate
+
+
+def assert_valid_schema(data, schema_file):
+    """Assert json data using json schema file"""
+
+    schema = _load_json_schema(schema_file)
+    return validate(data, schema)
+
+
+def _load_json_schema(schema_file):
+    """Load json schema file"""
+
+    relative_path = join('schemas', schema_file)
+    absolute_path = join(dirname(__file__), relative_path)
+
+    with open(absolute_path) as f:
+        return json.load(f)

--- a/pytest/support/request.py
+++ b/pytest/support/request.py
@@ -1,0 +1,33 @@
+import json
+import requests
+
+HOST = 'http://localhost:3001'
+DEFAULT_USER = 'ほげ茶'
+DEFAULT_PASSWORD = 'password'
+
+
+def get_token(name=None, password=None):
+    """Get X-Authorized-Token"""
+
+    if name is None:
+        name = DEFAULT_USER
+    if password is None:
+        password = DEFAULT_PASSWORD
+
+    r = requests.post(HOST + '/signin', {'name': name, 'password': password})
+    data = json.loads(r.text)
+    return data['token']
+
+
+def request(method, url, data=None):
+    """Send authorized request with token"""
+
+    if data is None:
+        data = {}
+
+    # Set authorized token
+    token = get_token()
+    headers = {'X-Authorized-Token': token}
+
+    r = requests.request(method, HOST + url, data=data, headers=headers)
+    return json.loads(r.text)

--- a/pytest/support/schemas/seller.json
+++ b/pytest/support/schemas/seller.json
@@ -1,0 +1,25 @@
+{
+  "title": "Seller",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "number"
+    },
+    "name": {
+      "type": "string"
+    },
+    "token": {
+      "type": "string"
+    },
+    "twitter_name": {
+      "type": ["string", "null"]
+    },
+    "twitter_screen_name": {
+      "type": ["string", "null"]
+    },
+    "twitter_image_url": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": ["id", "name", "token"]
+}

--- a/pytest/test_sellers.py
+++ b/pytest/test_sellers.py
@@ -1,0 +1,10 @@
+from support.request import request
+from support.assertions import assert_valid_schema
+
+
+def test_get_sellers():
+    """Can get my seller object"""
+
+    data = request('get', '/sellers')
+    assert_valid_schema(data, 'seller.json')
+

--- a/pytest/test_sessions.py
+++ b/pytest/test_sessions.py
@@ -1,0 +1,8 @@
+from support.request import get_token
+
+
+def test_post_signin():
+    """Can get authorized token"""
+
+    token = get_token()
+    assert token is not None and token != ''


### PR DESCRIPTION
もう使わないと思いますが、前から使ってみたかったJSON Schemaを使ってテストを一部だけ書いてみました(ただしPythonで)。JSON Schemaを使うと、ドキュメントを自動生成できて便利らしいです。

参考ページ: [Testing Your Python API App with JSON Schema – Grammofy – Medium](https://medium.com/grammofy/testing-your-python-api-app-with-json-schema-52677fe73351)