### PR TITLE
販売履歴を保存するSalesLogモデルを追加し、POST [/Register]時にSalesLogを登録する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,9 +1107,12 @@ X-Authorized-Token: q2w5ARRr62KEZqGSUGCfzjE6
             "id": 2,
             "count": 5
         },
-    ]
+    ],
+    "deposit": 20000
 }
 ```
+
+`deposit`: 預かり金額
 
 ### response
 
@@ -1178,6 +1181,39 @@ HTTP 404 Not Found
     "errors": {
         "id": [
             "is not found"
+        ]
+    }
+}
+```
+
+必要なリクエストパラメータが不足している場合
+
+```
+HTTP 400 Bad Request
+```
+
+```json
+{
+    "errors": {
+        "deposit": [
+            "can't be blank",
+            "is not a number"
+        ]
+    }
+}
+```
+
+上記以外に何らかの理由でトランザクションのコミットに失敗した場合
+
+```
+HTTP 400 Bad Request
+```
+
+```json
+{
+    "errors": {
+        "transaction": [
+            "Some errors have occurred"
         ]
     }
 }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   has_many :event_items
+  has_many :sales_logs
   belongs_to :seller
   validates :name, presence: true, length: {minimum: 1}
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,3 +1,4 @@
 class Log < ApplicationRecord
   belongs_to :event_item
+  belongs_to :sales_log, optional: true
 end

--- a/app/models/sales_log.rb
+++ b/app/models/sales_log.rb
@@ -1,0 +1,6 @@
+class SalesLog < ApplicationRecord
+  belongs_to :event
+  has_many :logs, :dependent => :delete_all
+  has_many :event_items, through: :logs
+  validates :deposit, presence: true, numericality: {greater_than_or_equal_to: 0}
+end

--- a/db/migrate/20171227085932_create_sales_logs.rb
+++ b/db/migrate/20171227085932_create_sales_logs.rb
@@ -1,0 +1,10 @@
+class CreateSalesLogs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sales_logs do |t|
+      t.references :event, foreign_key: true
+      t.integer :deposit
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171227090957_add_sales_log_to_log.rb
+++ b/db/migrate/20171227090957_add_sales_log_to_log.rb
@@ -1,0 +1,5 @@
+class AddSalesLogToLog < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :logs, :sales_log, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171203172412) do
+ActiveRecord::Schema.define(version: 20171227090957) do
 
   create_table "event_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "price"
@@ -43,7 +43,17 @@ ActiveRecord::Schema.define(version: 20171203172412) do
     t.integer "diff_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "sales_log_id"
     t.index ["event_item_id"], name: "index_logs_on_event_item_id"
+    t.index ["sales_log_id"], name: "index_logs_on_sales_log_id"
+  end
+
+  create_table "sales_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "event_id"
+    t.integer "deposit"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_sales_logs_on_event_id"
   end
 
   create_table "sellers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -63,4 +73,6 @@ ActiveRecord::Schema.define(version: 20171203172412) do
   add_foreign_key "events", "sellers"
   add_foreign_key "items", "sellers"
   add_foreign_key "logs", "event_items"
+  add_foreign_key "logs", "sales_logs"
+  add_foreign_key "sales_logs", "events"
 end

--- a/spec/factories/sales_logs.rb
+++ b/spec/factories/sales_logs.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :sales_log do
+    event nil
+    deposit 1
+  end
+end

--- a/spec/models/sales_log_spec.rb
+++ b/spec/models/sales_log_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SalesLog, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# SalesLog モデル

1回のお会計の履歴を記録する。

- `deposit`: 購入者が販売者に支払った金額

|SalesLog|
|:---------|
|+ event_id:bigint {refers to Event}|
|+ deposit:integer {greater than or equal to 0}|

- `SalesLog.an_instance.event_items`で該当するお会計で売れた商品の一覧が取得できる

# Log モデル

|Log|
|:---|
| ~ 既存のものは省略 ~ |
|+ sales_log_id:bigint = nil {allow nil, refers to SalesLog}|

# POST [/register]

## request

```
X-Authorized-Token: q2w5ARRr62KEZqGSUGCfzjE6
```


```json
{
    "event_id": 1,
    "items": [
        {
            "id": 1,
            "count": 3
        },
        {
            "id": 2,
            "count": 5
        },
    ],
    "deposit": 20000
}
```

`deposit`: 預かり金額
