### PR TITLE
販売履歴の各商品の小計と合計金額を当時の商品価格を参照するよう修正, fixed #92

### DIFF
--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -32,7 +32,7 @@ class RegisterController < ApplicationController
               # アイテムが見つからない場合
               return render json: { 'errors': { id: ['is not found'] }}, status: :not_found
             end
-            log = event_item.logs.new(diff_count: item['count'], sales_log: sales_log)
+            log = event_item.logs.new(diff_count: item['count'], sales_log: sales_log, current_price: event_item.price)
             log.save!
             item = Item.find_by(id: item['id'])
             tweet = "#{item.seller.name}の「#{item.name}」は残り#{event_item.logs.sum(:diff_count)}個になりました！"

--- a/app/controllers/sales_logs_controller.rb
+++ b/app/controllers/sales_logs_controller.rb
@@ -24,7 +24,7 @@ class SalesLogsController < ApplicationController
           logs_array = []
           sales_log.logs.each do |log|
             count = -log.diff_count
-            subtotal = log.event_item.price * count
+            subtotal = (log.current_price || log.event_item.price) * count
             logs_array.push({ name: log.event_item.item.name, count: count, subtotal: subtotal })
             total += subtotal
           end

--- a/db/migrate/20171228153230_add_current_price_to_logs.rb
+++ b/db/migrate/20171228153230_add_current_price_to_logs.rb
@@ -1,0 +1,5 @@
+class AddCurrentPriceToLogs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :logs, :current_price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171227090957) do
+ActiveRecord::Schema.define(version: 20171228153230) do
 
   create_table "event_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "price"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20171227090957) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "sales_log_id"
+    t.integer "current_price"
     t.index ["event_item_id"], name: "index_logs_on_event_item_id"
     t.index ["sales_log_id"], name: "index_logs_on_sales_log_id"
   end


### PR DESCRIPTION
Logモデルにcurrent_priceカラムを追加し、POST [/register]時に現在価格を保存するよう修正