### PR TITLE
EventItemにdeletedカラムを追加し、それがtrueであればEventItemを削除したとみなすように変更, fixed #94

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -13,11 +13,11 @@ class EventsController < ApplicationController
     elsif @event.seller != @seller
       render json: { errors: { id: ['is not yours'] }}, status: :forbidden
     else
-      event_items = EventItem.where(event_id: @event.id)
+      event_items = EventItem.where(event_id: @event.id, deleted: false)
       items = []
       event_items.each do |event_item|
         item = Item.find_by(id: event_item.item_id)
-        price = EventItem.find_by(item_id: item.id).price
+        price = EventItem.find_by(item_id: item.id, deleted: false).price
         count = event_item.logs.sum(:diff_count)
         items.push({
             price: price,
@@ -45,7 +45,7 @@ class EventsController < ApplicationController
       return render json: { id: @event.id, name: @event.name }, status: :created
     else
       return render json: { errors: @event.errors.messages }, status: :bad_request
-   end
+    end
   end
 
   def update
@@ -106,7 +106,7 @@ class EventsController < ApplicationController
       # イベントの所有者はトークンを持つカレントユーザと同一なので、ログ出力を許可
       items = []
       sales = 0
-      @event.event_items.each do |item|
+      @event.event_items.where(deleted: false).each do |item|
         subcounts = -item.logs.where("diff_count < 0").sum(:diff_count)
         subsales = subcounts * item.price
         sales += subsales

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -27,7 +27,7 @@ class RegisterController < ApplicationController
             end
             # 販売数が 0 だった場合は記録せずにスキップする
             next if item['count'].zero?
-            event_item = EventItem.find_by(event_id: json_request['event_id'], item_id: item['id'])
+            event_item = EventItem.find_by(event_id: json_request['event_id'], item_id: item['id'], deleted: false)
             if event_item.nil?
               # アイテムが見つからない場合
               return render json: { 'errors': { id: ['is not found'] }}, status: :not_found
@@ -58,9 +58,9 @@ class RegisterController < ApplicationController
 
         # 最新のアイテムリストを返す
         items = []
-        event.event_items.each do |event_item|
+        event.event_items.where(deleted: false).each do |event_item|
           item = Item.find_by(id: event_item.item_id)
-          price = EventItem.find_by(item_id: item.id).price
+          price = EventItem.find_by(item_id: item.id, deleted: false).price
           count = event_item.logs.sum(:diff_count)
           items.push({
                          price: price,

--- a/db/migrate/20171228164606_add_deleted_to_event_items.rb
+++ b/db/migrate/20171228164606_add_deleted_to_event_items.rb
@@ -1,0 +1,5 @@
+class AddDeletedToEventItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :event_items, :deleted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171227090957) do
+ActiveRecord::Schema.define(version: 20171228164606) do
 
   create_table "event_items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "price"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20171227090957) do
     t.bigint "event_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "deleted", default: false
     t.index ["event_id"], name: "index_event_items_on_event_id"
     t.index ["item_id"], name: "index_event_items_on_item_id"
   end


### PR DESCRIPTION
#94 の問題を修正。
EventItemのレコードは永続的なものとし、新たに追加するdeletedカラムをtrueにしたものを「削除した」とみなすようにする。